### PR TITLE
Add Drupal 11 setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # MyDrupal
+
+This repository provides instructions for setting up a Drupal 11 environment with the Gin backend theme and Gin Login.
+
+## Requirements
+
+- Docker and Docker Compose
+- Composer
+- Drush (optional for enabling modules from the command line)
+
+## Quick setup
+
+1. Create a new Drupal 11 project:
+
+   ```bash
+   composer create-project drupal/recommended-project mysite
+   cd mysite
+   ```
+
+2. Add the Gin theme and Gin Login module:
+
+   ```bash
+   composer require drupal/gin drupal/gin_login
+   ```
+
+3. Start the site with Docker Compose by using the provided `docker-compose.yml`:
+
+   ```bash
+   docker compose up -d
+   ```
+
+4. After the site installs, enable Gin and Gin Login:
+
+   ```bash
+   vendor/bin/drush en gin gin_login -y
+   vendor/bin/drush config-set system.theme admin gin -y
+   ```
+
+Your Drupal 11 site will be available on <http://localhost:8080> with the Gin admin theme and login page.
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  drupal:
+    image: drupal:11
+    ports:
+      - "8080:80"
+    volumes:
+      - ./mysite:/var/www/html
+    environment:
+      - PHP_MEMORY_LIMIT=512M

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+composer create-project drupal/recommended-project mysite
+cd mysite
+composer require drupal/gin drupal/gin_login
+


### PR DESCRIPTION
## Summary
- add a README with steps to spin up Drupal 11 with Gin
- provide a Docker compose file
- add a helper setup script for composer

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68487b1a5e5c832a8a81521a1af533cd